### PR TITLE
Preserve hash references in commit logs

### DIFF
--- a/join-git-repos.py
+++ b/join-git-repos.py
@@ -454,7 +454,7 @@ def mergerpos(main_commands, secondary_commands, main_spec, secondary_spec):
 # Handle the program arguments.
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
-    description='Generate a new repository with stiched histories from two or more repositories.',
+    description='Generate a new repository with stitched histories from two or more repositories.',
     epilog=('A repository specification is given on the following format:\n' +
            '  path[,name][:mainbranch]\n' +
            '    path       - Root of the Git repository.\n' +
@@ -463,7 +463,7 @@ parser = argparse.ArgumentParser(
            '    mainbranch - The main branch of the repository.\n' +
            '                 (default: master)\n'))
 parser.add_argument('-n', '--no-subdirs', action='store_true', help='do not create subdirectories')
-parser.add_argument('-o', '--output', metavar='OUTPUT', required='True', help='output directory for the stiched Git repo')
+parser.add_argument('-o', '--output', metavar='OUTPUT', required='True', help='output directory for the stitched Git repo')
 parser.add_argument('main', metavar='MAIN', help='main repository specification')
 parser.add_argument('secondary', metavar='SECONDARY', nargs='+', help='secondary repository specification')
 args = parser.parse_args()
@@ -500,7 +500,7 @@ for secondary in args.secondary:
     print('\nMerging repositories...')
     main_commands = mergerpos(main_commands, secondary_commands, main_spec, secondary_spec)
 
-# Create the new repository and import the stiched histories.
+# Create the new repository and import the stitched histories.
 out_root = args.output
 if os.path.isdir(out_root):
     cleandir(out_root)

--- a/join-git-repos.py
+++ b/join-git-repos.py
@@ -98,11 +98,11 @@ def makeimport(exp):
 
 # Export a repository.
 def exportrepo(repo_root):
-    cmd = ['git', '-C', repo_root, 'fast-export', '--all']
+    cmd = ['git', '-C', repo_root, 'fast-export', '--all', '--show-original-ids']
     return parseexport(subprocess.check_output(cmd))
 
 # Import to a new repository.
-def importtorepo(repo_root, commands, branch):
+def importtorepo(repo_root, commands, branch, use_git_filter_repo):
     # Generate a string from the export description.
     import_str = makeimport(commands)
 
@@ -110,9 +110,15 @@ def importtorepo(repo_root, commands, branch):
     cmd = ['git', 'init', repo_root]
     subprocess.check_call(cmd)
 
-    # Import the fast-import string into the repo.
-    p = subprocess.Popen(['git', '-C', repo_root, 'fast-import'], stdin=subprocess.PIPE)
-    p.communicate(input=import_str)
+    if(use_git_filter_repo):
+        # Import the fast-import string into the repo using git-filter-repo
+        # This will update hash references in commit logs.
+        p = subprocess.Popen(['git-filter-repo', '--target', repo_root, '--stdin'], stdin=subprocess.PIPE)
+        p.communicate(input=import_str)
+    else:
+        # Import the fast-import string into the repo.
+        p = subprocess.Popen(['git', '-C', repo_root, 'fast-import'], stdin=subprocess.PIPE)
+        p.communicate(input=import_str)
 
     # Checkout the tip of the main branch.
     cmd = ['git', '-C', repo_root, 'reset', '--hard', branch]
@@ -268,6 +274,9 @@ def getlog(commands, branch, repo_id):
             # Find the tip of the branch. (Is directly intruduced by a commit command)
             elif (cmd[:7] == b'commit ') and (cmd[7:] in ref_names):
                 cmd2_idx = k + 2
+                # 'original-oid' (optional) comes after 'mark'.
+                if commands[cmd2_idx][:13] == b'original-oid ':
+                    cmd2_idx = cmd2_idx + 1
                 # 'author' (optional) comes after 'mark'.
                 if commands[cmd2_idx][:7] == b'author ':
                     cmd2_idx = cmd2_idx + 1
@@ -284,6 +293,9 @@ def getlog(commands, branch, repo_id):
         # Find the next parent commit.
         elif (cmd[:7] == b'commit ') and (commands[k + 1] == parent_mark):
             cmd2_idx = k + 2
+            # 'original-oid' (optional) comes after 'mark'.
+            if commands[cmd2_idx][:13] == b'original-oid ':
+                cmd2_idx = cmd2_idx + 1
             # 'author' (optional) comes after 'mark'.
             if commands[cmd2_idx][:7] == b'author ':
                 cmd2_idx = cmd2_idx + 1
@@ -423,7 +435,7 @@ def mergerpos(main_commands, secondary_commands, main_spec, secondary_spec):
                     cmd = src_commands[i]
                     space_pos = cmd.find(b' ')
                     cmd_type = cmd[:space_pos] if space_pos > 0 else cmd
-                    if not (cmd_type in [b'mark', b'author', b'committer', b'data', b'from', b'merge', b'M', b'D', b'C', b'R', b'deleteall', b'N']):
+                    if not (cmd_type in [b'mark', b'original-oid', b'author', b'committer', b'data', b'from', b'merge', b'M', b'D', b'C', b'R', b'deleteall', b'N']): #,
                         source['idx'] = i
                         processed_all_commands = False
                         break
@@ -463,6 +475,7 @@ parser = argparse.ArgumentParser(
            '    mainbranch - The main branch of the repository.\n' +
            '                 (default: master)\n'))
 parser.add_argument('-n', '--no-subdirs', action='store_true', help='do not create subdirectories')
+parser.add_argument('-p', '--use-git-filter-repo', action='store_true', help='preserve hash references in commit messages by using git-filter-repo to import the stiched repo')
 parser.add_argument('-o', '--output', metavar='OUTPUT', required='True', help='output directory for the stitched Git repo')
 parser.add_argument('main', metavar='MAIN', help='main repository specification')
 parser.add_argument('secondary', metavar='SECONDARY', nargs='+', help='secondary repository specification')
@@ -470,6 +483,7 @@ args = parser.parse_args()
 
 # Should we append subdirs?
 move_to_subdirs = not args.no_subdirs
+use_git_filter_repo = args.use_git_filter_repo
 
 # TODO(m): Support more than one repo with submodules (requires merging .gitmodules from several
 # repos, over time, ...).
@@ -507,5 +521,5 @@ if os.path.isdir(out_root):
 else:
     os.makedirs(out_root)
 print('\nImporting result to ' + os.path.abspath(out_root) + '...')
-importtorepo(out_root, main_commands, main_spec['branch'])
+importtorepo(out_root, main_commands, main_spec['branch'], use_git_filter_repo)
 


### PR DESCRIPTION
One defect I couldn't get around for join-git-repos was the need to retain meaning in commit logs that say things like "cherry-picked from < hash >". Git-filter-repo handles this nicely, but doesn't provide a join facility. I was able to combine these tools by adding `original-oid` to the export data and modifying join-git-repos to delegate to git-filter-repo rather than fast-import. The new -p option adds a dependency on git-filter-repo, but makes this tool much more complete.