### PR TITLE
Removes remapping of tags to new marks

### DIFF
--- a/join-git-repos.py
+++ b/join-git-repos.py
@@ -408,7 +408,7 @@ def mergerpos(main_commands, secondary_commands, main_spec, secondary_spec):
         processed_all_commands = True
         first_commit_of_branch = (source['idx'] == 0)
         mark_before_break = b''
-        expectingTagFromMark = False
+        expecting_tag_from_mark = False
         for k in range(source['idx'], len(src_commands)):
             if (not log_done) and (src_commands[k] == next_mark):
                 # Sanity check: The previous command must be a 'commit'.
@@ -449,9 +449,9 @@ def mergerpos(main_commands, secondary_commands, main_spec, secondary_spec):
                 # Handle the tail end of the fast-export file.
                 # Append the command to the command queue, with parent remapping.
                 # However, tags are a special case and should not have marks remapped.
-                if expectingTagFromMark:
+                if expecting_tag_from_mark:
                     commands.append(src_commands[k])
-                    expectingTagFromMark = False
+                    expecting_tag_from_mark = False
                 else:
                     commands.append(remapmark(src_commands[k], mark_map))
                 
@@ -462,7 +462,7 @@ def mergerpos(main_commands, secondary_commands, main_spec, secondary_spec):
                 cmd_type = cmd[:space_pos] if space_pos > 0 else cmd
                 if (cmd_type == b'tag'):
                     # If it's a tag, the next command will be a from :mark that we don't want to remap
-                    expectingTagFromMark = True
+                    expecting_tag_from_mark = True
                 
 
         if processed_all_commands:


### PR DESCRIPTION
Tags are a special case and should not have their parent mark remapped. With the current arguments to fast-export (which don't include --mark-tags for example) tags are formatted like this:

tag 1.5.0
from :3493
original-oid eb12ca36ae2a859ba1ae262e1c9153b062940140

The previous implementation called
`commands.append(remapmark(src_commands[k], mark_map))` for every line of the fast-export. To avoid remapping the tag "from" marks, a state variable is introduced to track if a "tag from mark" is expected, in which case the command is appended without remapping.

Also of note, the tags are all placed at the end of the fast-export stream, so this special case handling is done after the logs are merged, when the tail end of the commands are handled.